### PR TITLE
2025 Survey Draft Updates

### DIFF
--- a/surveys/sphinx-survey-2025.yml
+++ b/surveys/sphinx-survey-2025.yml
@@ -32,19 +32,6 @@ questions:
       - "I maintain a Sphinx theme"
       - "I contribute to Sphinx"
 
-  - title: "Which of the following roles is closest to your job?"
-    other: true
-    choices:
-      - "Academic researcher"
-      - "Data scientist"
-      - "Developer / Programmer"
-      - "ML engineer / MLOps"
-      - "Product manager"
-      - "QA engineer"
-      - "Technical support"
-      - "Technical writer"
-      - "Prefer not to answer"
-
   - title: "Do you most often work on a team or independently?"
     other: true
     choices:
@@ -103,6 +90,11 @@ questions:
       - "Mkdocs"
       - "JupyterBook"
       - "Sphinx"
+      - "Hugo"
+      - "Astro"
+      - "Pelican"
+      - "Nikola"
+      - "Eleventy"
       - "None"
       - "I don’t know"
 
@@ -113,7 +105,14 @@ questions:
       - "GitHub Pages"
       - "Netlify"
       - "Read The Docs"
+      - "Vercel" 
+      - "Cloudflare Pages"
+      - "DigitalOcean"
+      - "Hetzner" 
+      - "Render"
+      - "Vultr"
       - "My institution has its own deployment"
+      - "I don't know"
 
   - title: "What markup language are you using in your documentation?"
     multiple: true
@@ -178,9 +177,9 @@ questions:
   - title: "What is the main reason you use Sphinx?"
     other: true
     choices:
-      - "Python API documentation generation (docstrings)"
-      - "Narrative documentation"
-      - "Educational materials"
+      - "API documentation generation from docstrings"
+      - "Being able to reference to other pages/sections across one or multiple sites"
+      - "Add functionality through extensions"
       - "Other projects in my ecosystem were using Sphinx"
       - "Someone on my team knew how to use Sphinx"
       - "I joined a project that was already using Sphinx"
@@ -188,6 +187,7 @@ questions:
       - "Sphinx’s performance"
       - "Sphinx’s stability"
       - "Sphinx’s release schedule"
+  
 
   - title: "Does your project use custom Sphinx extensions?"
     choices:
@@ -205,6 +205,8 @@ questions:
       - "Read The Docs"
       - "Pydata Sphinx Theme"
       - "Material design"
+      - "Furo"
+      - "Python Docs Sphinx Theme"
       - "Something else/I don’t know"
 
   - title: "In which formats do you publish your documentation with sphinx?"
@@ -214,20 +216,6 @@ questions:
       - "HTML"
       - "PDF"
       - "EPUB"
-
-  - title: "How comfortable do you feel when working with docutils?"
-    choices:
-      - "Very comfortable"
-      - "Comfortable"
-      - "Neutral"
-      - "Uncomfortable"
-      - "Very uncomfortable"
-      - "I don't know or don't work with docutils"
-
-  - title:
-      "What is the biggest challenge you face when searching for documentation
-      on Sphinx internals?"
-    type: long_text
 
   - title:
       "Please rank the issues you face when working with Sphinx from 1 (most

--- a/surveys/sphinx-survey-2025.yml
+++ b/surveys/sphinx-survey-2025.yml
@@ -1,5 +1,11 @@
 # Copyright (c) 2025, Quansight Inc.
 
+# Objective: Gain basic insight about about Sphinx in the wild; who is using it, for what, with what, and with what priorities?
+# The goal is to augment discussions on features and issues with feedback that can be followed up on. The survey will not provide prescriptive solutions.
+
+# Target audience: People who interact with documentation, especially those who contribute to or extend documentation. Use of Sphinx is encouraged but not required.
+
+
 title: "Sphinx Survey 2025"
 questions:
   - title: "Sphinx Usage Survey 2025"
@@ -31,6 +37,7 @@ questions:
       - "I build extensions for Sphinx"
       - "I maintain a Sphinx theme"
       - "I contribute to Sphinx"
+      - "None of the above"
 
   - title: "Which of the following roles is closest to your job?"
   other: true

--- a/surveys/sphinx-survey-2025.yml
+++ b/surveys/sphinx-survey-2025.yml
@@ -177,8 +177,8 @@ questions:
   - title: "What is the main reason you use Sphinx?"
     other: true
     choices:
-      - "API documentation generation from docstrings"
-      - "Being able to reference to other pages/sections across one or multiple sites"
+      - "API documentation generation from Python docstrings"
+      - "Being able to cross-reference other pages/sections across one or multiple sites ('intersphinx')"
       - "Add functionality through extensions"
       - "Other projects in my ecosystem were using Sphinx"
       - "Someone on my team knew how to use Sphinx"
@@ -207,6 +207,11 @@ questions:
       - "Material design"
       - "Furo"
       - "Python Docs Sphinx Theme"
+      - "Sphinx Book Theme"
+      - "Shibuya"
+      - "Sphinx Immaterial"
+      - "Sphinx Awesome Theme"
+      - "Sphinx Bootstrap Theme"
       - "Something else/I don’t know"
 
   - title: "In which formats do you publish your documentation with sphinx?"

--- a/surveys/sphinx-survey-2025.yml
+++ b/surveys/sphinx-survey-2025.yml
@@ -32,6 +32,19 @@ questions:
       - "I maintain a Sphinx theme"
       - "I contribute to Sphinx"
 
+  - title: "Which of the following roles is closest to your job?"
+  other: true
+  choices:
+    - "Academic researcher"
+    - "Data scientist"
+    - "Developer / Programmer"
+    - "ML engineer / MLOps"
+    - "Product manager"
+    - "QA engineer"
+    - "Technical support"
+    - "Technical writer"
+    - "Prefer not to answer"
+
   - title: "Do you most often work on a team or independently?"
     other: true
     choices:
@@ -112,6 +125,7 @@ questions:
       - "Vercel" 
       - "Vultr"
       - "We have our own deployment"
+      - "As a part of an existing website"
       - "I don't know"
 
   - title: "What markup language are you using in your documentation?"

--- a/surveys/sphinx-survey-2025.yml
+++ b/surveys/sphinx-survey-2025.yml
@@ -72,29 +72,29 @@ questions:
     multiple: true
     other: true
     choices:
+      - "Community manager"
       - "Designer"
       - "Developer"
       - "Data scientist"
       - "Educator"
-      - "Technical writer"
-      - "Community manager"
-      - "Testing engineer"
       - "Extension developer/maintainer"
+      - "Technical writer"
+      - "Testing engineer"
 
   - title: "What documentation engines do you use?"
     multiple: true
     other: true
     choices:
-      - "MyST"
-      - "Docusaurus"
-      - "Mkdocs"
-      - "JupyterBook"
-      - "Sphinx"
-      - "Hugo"
       - "Astro"
-      - "Pelican"
-      - "Nikola"
+      - "Docusaurus"
       - "Eleventy"
+      - "Hugo"
+      - "JupyterBook"
+      - "Mkdocs"
+      - "MyST"
+      - "Nikola"
+      - "Pelican"
+      - "Sphinx"
       - "None"
       - "I don’t know"
 
@@ -102,34 +102,40 @@ questions:
     multiple: true
     other: true
     choices:
-      - "GitHub Pages"
-      - "Netlify"
-      - "Read The Docs"
-      - "Vercel" 
       - "Cloudflare Pages"
       - "DigitalOcean"
+      - "GitHub Pages"
       - "Hetzner" 
+      - "Netlify"
+      - "Read The Docs"
       - "Render"
+      - "Vercel" 
       - "Vultr"
-      - "My institution has its own deployment"
+      - "We have our own deployment"
       - "I don't know"
 
   - title: "What markup language are you using in your documentation?"
     multiple: true
     other: true
     choices:
-      - "Markdown"
+      - "AsciiDoc"
+      - "Confluence/Jira"
+      - "Markdown - CommonMark"
+      - "Markdown - GitHub Flavored Markdown"
+      - "Markdown - MyST"
       - "reStructuredText"
+      - "TeX"
+      - "XML/DITA"
       - "I don’t know"
 
   - title: "What markup language are you using in your docstrings?"
     multiple: true
     other: true
     choices:
-      - "Markdown"
-      - "reStructuredText"
-      - "Numpydoc format"
       - "Google format"
+      - "Markdown"
+      - "Numpydoc format"
+      - "reStructuredText"
       - "I don’t know"
 
   - title:
@@ -138,9 +144,9 @@ questions:
     other: true
     choices:
       - "Ease of use"
+      - "Frequent updates"
       - "Performance"
       - "Stability"
-      - "Frequent updates"
       - "Variety of features"
 
   - title: "Why did you choose the engine you use for your documentation?"
@@ -148,9 +154,9 @@ questions:
     other: true
     choices:
       - "Ease of use"
+      - "Frequent updates"
       - "Performance"
       - "Stability"
-      - "Frequent updates"
       - "Variety of features"
       - "Other projects in my ecosystem were using it"
       - "It was chosen by others on the project"
@@ -202,25 +208,30 @@ questions:
     choices:
       - "Whatever comes with Sphinx by default"
       - "Alabaster"
-      - "Read The Docs"
-      - "Pydata Sphinx Theme"
-      - "Material design"
       - "Furo"
+      - "Material design"
+      - "Pydata Sphinx Theme"
       - "Python Docs Sphinx Theme"
-      - "Sphinx Book Theme"
+      - "Read The Docs"
       - "Shibuya"
-      - "Sphinx Immaterial"
       - "Sphinx Awesome Theme"
+      - "Sphinx Book Theme"
       - "Sphinx Bootstrap Theme"
+      - "Sphinx Immaterial"
       - "Something else/I don’t know"
 
   - title: "In which formats do you publish your documentation with sphinx?"
     multiple: true
     other: true
     choices:
-      - "HTML"
-      - "PDF"
       - "EPUB"
+      - "HTML"
+      - "JSON serialisation"
+      - "manpages / manual pages"
+      - "PDF"
+      - "Plain text"
+      - "Texinfo"
+      - "XML"
 
   - title:
       "Please rank the issues you face when working with Sphinx from 1 (most
@@ -231,11 +242,11 @@ questions:
       should resources be allocated."
     type: ranking
     choices:
-      - "reStructuredText syntax is too complicated"
-      - "Sphinx is missing features I want"
-      - "Performance issues"
-      - "Sphinx breaks too often"
       - "No native support for Markdown"
+      - "Performance issues"
+      - "reStructuredText syntax is too complicated"
+      - "Sphinx breaks too often"
+      - "Sphinx is missing features I want"
 
   - title: "Are there any other issues you face when working with Sphinx?"
     type: long_text


### PR DESCRIPTION
I'm proposing updates to the 2025 survey draft based on feedback in [sphinx-doc discussions #13331](https://github.com/orgs/sphinx-doc/discussions/13331). 

I've integrated a majority of the changes (though I imagine there may be feedback on the best way to do that) except for 

> I'd like to have insights into preference (How important is ...) and satisfaction (How satisfied are you with ...) on topics like
> 
> - Performance
> - Stability
> - Ease of use (Maybe subtopics: setup, learn, write, build, customize)
> - Sphinx own documentation
> - Default theme
> - Builtin themes
> - ReST vs. Markdown
> - Extension ecosystem
> - API documentation generation

Drafts of these questions or how they may be integrated into existing questions are not in this PR. This is something I'm still considering the best approach for, but I didn't want to keep holding up the other changes longer.

As always, feedback is very much welcome and I will do my best to answer any questions. Thank you for making this repository and being open to the survey!